### PR TITLE
tests+auth: CORS/SSE middleware bypass, debug route, and frontend auth tests

### DIFF
--- a/backend/app/api/routers/agents.py
+++ b/backend/app/api/routers/agents.py
@@ -55,6 +55,12 @@ async def list_agents(auth=Depends(require_auth), db: Session = Depends(get_db))
     return [{"id": r.id, "display_name": r.display_name} for r in rows]
 
 
+
+@router.get("/debug/me")
+async def debug_me(auth=Depends(require_auth)):
+    return auth
+
+
 @router.get("/agents/{agent_id}")
 async def get_agent(
     agent_id: str, auth=Depends(require_auth), db: Session = Depends(get_db)

--- a/docs/poc-checklist.md
+++ b/docs/poc-checklist.md
@@ -157,6 +157,10 @@ Acceptance Test
 - [x] Protected API with REST token verification (Stack /users/me) in FastAPI
 - [x] AuthZ: team-based org_id scoping and ownership checks on GET/POST agents
 - [x] Backend middleware: coarse auth on /v1/*, attaches auth context
+- [x] CORS/Preflight: auth middleware bypasses OPTIONS so CORSMiddleware can reply
+- [x] SSE Streams: auth middleware allows /v1/agents/{id}/logs and /v1/runs/{id}/stream (handler verifies via query token)
+- [x] Debug: GET /v1/debug/me returns auth context for troubleshooting
+
 - [x] Stricter endpoints: X-Team-Id mandatory for create/invoke; membership verified
 - [ ] Tenant isolation: Postgres Row-Level Security (RLS) policies (scaffolded: SET LOCAL app.org_id)
 - [ ] API Keys: per-agent, hashed at rest, scoped to capabilities
@@ -192,7 +196,7 @@ Acceptance Test
 ## Current Sprint (PoC acceptance — 1–2 weeks)
 
 Instructions Pack
-- [ ] API: GET /v1/agents/{agent_id}/instructions returns concrete snippets (n8n/Make/LangChain/OpenAI/Claude/MCP) — IN PROGRESS
+- [x] API: GET /v1/agents/{agent_id}/instructions returns concrete snippets (n8n/Make/LangChain/OpenAI/Claude/MCP) — DONE
 - [ ] UI: Instructions page with copy-to-clipboard and <host>/<agent-id> variableization — IN PROGRESS
 
 Streaming Logs + Persistence
@@ -202,11 +206,11 @@ Streaming Logs + Persistence
 
 Logs UI
 - [x] Endpoints: GET /v1/runs and GET /v1/runs/{id}/logs
-- [x] Minimal Logs page with Live toggle; filters (agent/status) — PARTIAL
+- [x] Minimal Logs page with Live toggle; filters (agent/status)
 
 Security & Platform
 - [ ] Postgres RLS policies in place + middleware to SET LOCAL app.org_id; enforcement tests
-- [ ] CI on PRs: frontend (lint, typecheck, Jest), backend (ruff, black --check, mypy, pytest)
+- [x] CI on PRs: frontend (lint, typecheck, Jest), backend (ruff, black --check, mypy, pytest)
 
 Optional (in parallel): Protocols
 - [ ] /.well-known/a2a/{agent_id}.json — signed (static initial)

--- a/frontend/src/app/(main)/agents/new/page.tsx
+++ b/frontend/src/app/(main)/agents/new/page.tsx
@@ -6,6 +6,7 @@ import { Card } from "~/components/ui/card";
 import { Textarea } from "~/components/ui/textarea";
 import { Button } from "~/components/ui/button";
 import { Label } from "~/components/ui/label";
+import { env } from "~/env";
 
 export default function NewAgentPage() {
   const [brief, setBrief] = useState("");
@@ -17,7 +18,7 @@ export default function NewAgentPage() {
     e.preventDefault();
     setSubmitting(true);
     try {
-      const res = await authFetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/v1/agents`, {
+      const res = await authFetch(`${env.NEXT_PUBLIC_API_BASE_URL}/v1/agents`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ brief }),

--- a/frontend/src/app/(main)/agents/page.tsx
+++ b/frontend/src/app/(main)/agents/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { useAuthFetch } from "~/lib/authFetch";
 import { Card } from "~/components/ui/card";
+import Link from "next/link";
 
 export default function AgentsPage() {
   const authFetch = useAuthFetch();
@@ -16,7 +17,12 @@ export default function AgentsPage() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Agents</h1>
+      <div className="flex justify-between">
+          <h1 className="text-2xl font-bold">Agents</h1>
+        <Link className="rounded bg-indigo-600 px-3 py-1 text-white" href="/agents/new">Create New Agent</Link>
+      </div>
+    
+
       <Card className="p-4">
         <ul className="list-disc pl-6 text-sm">
           {agents.map((a) => (

--- a/frontend/src/app/(main)/dashboard-layout.tsx
+++ b/frontend/src/app/(main)/dashboard-layout.tsx
@@ -33,9 +33,9 @@ import OnboardingGate from "~/components/OnboardingGate";
 
 const links = [
   { href: "/", label: "Dashboard" },
-  { href: "/agents/new", label: "Agents" },
+  { href: "/agents", label: "Agents" },
   { href: "/playground", label: "Playground" },
-  { href: "/logs", label: "Logs" },
+  { href: "/execution-logs", label: "Logs" },
   { href: "/settings", label: "Settings" },
 ];
 
@@ -43,6 +43,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const pathname = usePathname();
   return (
     <SidebarProvider className="bg-muted/30" data-variant="inset">
+      <OnboardingGate />
+
       <Sidebar variant="inset" collapsible="icon">
         <SidebarHeader>
           <div className="px-2 py-1">

--- a/frontend/src/app/(main)/playground/page.tsx
+++ b/frontend/src/app/(main)/playground/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useUser } from "@stackframe/stack";
 import { useAuthFetch } from "~/lib/authFetch";
 import { Card } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
@@ -14,6 +15,7 @@ export default function PlaygroundPage() {
   const [stream, setStream] = useState<string[]>([]);
   const evtSrcRef = useRef<EventSource | null>(null);
   const authFetch = useAuthFetch();
+  const user = useUser();
 
   async function startInvoke() {
     setStream([]);
@@ -24,9 +26,9 @@ export default function PlaygroundPage() {
     });
 
     if (evtSrcRef.current) evtSrcRef.current.close();
-    // SSE: include auth token via ?token= and team via ?team= for PoC simplicity
-    const { accessToken } = await (await (useAuthFetch as any)().user?.getAuthJson?.()) ?? { accessToken: "" };
-    const teamId = (useAuthFetch as any)().user?.selectedTeam?.id ?? "";
+    // SSE: include auth token via ?token= and team via ?team=
+    const { accessToken } = await user!.getAuthJson();
+    const teamId = (user as any)?.selectedTeam?.id ?? "";
     const url = `${process.env.NEXT_PUBLIC_API_BASE_URL}/v1/agents/${agentId}/logs?since=now&token=${encodeURIComponent(accessToken)}&team=${encodeURIComponent(teamId)}`;
     const es = new EventSource(url);
     es.onmessage = (e) => setStream((s) => [...s, e.data]);


### PR DESCRIPTION
Summary
- Add backend tests for CORS OPTIONS bypass, SSE logs path bypass, and /v1/debug/me
- Add frontend Jest tests for useAuthFetch (Authorization, X-Team-Id preference) and Playground invoke/stream
- Fix hook usage in Playground and wire teamId through debug/test-auth page
- Improve Stack membership verification headers and CORS handling

Details
- Backend: auth middleware bypass for OPTIONS and SSE, /v1/debug/me endpoint
- Frontend: tests under src/lib/__tests__ and page tests

Checklist deltas
- [x] FastAPI tests for CORS/SSE/Debug
- [x] Jest tests for auth fetch and invoke/stream

Refs
- Closes #18
- Branch: feat/logs-filters-agents-page
- Commits: 263e097, 60b35bd

How to test
- frontend: npm test (Jest)
- backend: pytest -q


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author