### PR TITLE
M.1-02: Shared httpx.AsyncClient pooling and timeouts; lifecycle close

### DIFF
--- a/backend/app/security/opa.py
+++ b/backend/app/security/opa.py
@@ -8,7 +8,9 @@ import asyncio
 class OPAPolicyEngine:
     def __init__(self, opa_url: str = None):
         self.opa_url = opa_url or os.getenv("OPA_URL", "http://localhost:8181")
-        self.client = httpx.AsyncClient(timeout=5.0)
+        # Reuse shared pooled client for efficiency
+        from app.services.http_client import get_http_client
+        self.client = get_http_client()
     
     async def close(self):
         """Close the HTTP client."""

--- a/backend/app/services/http_client.py
+++ b/backend/app/services/http_client.py
@@ -1,0 +1,29 @@
+"""
+Shared HTTPX AsyncClient with connection pooling and sane timeouts.
+
+Use get_http_client() to obtain the singleton client.
+Start/stop handled from app.startup lifespan.
+"""
+from typing import Optional
+import httpx
+
+_client: Optional[httpx.AsyncClient] = None
+
+
+def get_http_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=0.5, read=1.5, write=1.5, pool=2.0),
+            limits=httpx.Limits(max_connections=50, max_keepalive_connections=20),
+            headers={"User-Agent": "collexa-backend/1.0"},
+        )
+    return _client
+
+
+async def close_http_client():
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -11,6 +11,7 @@ from contextlib import asynccontextmanager
 
 from app.services.scheduling.budget_scheduler_service import budget_scheduler
 from app.services.notifications.alert_service import alert_service
+from app.services.http_client import close_http_client
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,10 @@ async def lifespan(app):
         # Stop the budget scheduler
         await budget_scheduler.stop()
         logger.info("Budget scheduler stopped successfully")
+
+        # Close shared HTTP client
+        await close_http_client()
+        logger.info("HTTP client closed")
         
     except Exception as e:
         logger.error(f"Error during shutdown: {e}")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,3 +32,7 @@ redis>=5.0,<6.0
 apscheduler>=3.10,<4.0
 apprise>=1.7,<2.0
 
+
+
+# Performance testing (M.1)
+locust>=2.27,<3.0

--- a/backend/scripts/locustfile.py
+++ b/backend/scripts/locustfile.py
@@ -1,0 +1,63 @@
+import os
+import random
+from locust import HttpUser, task, between, events
+
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8000").rstrip("/")
+STACK_TOKEN = os.getenv("STACK_ACCESS_TOKEN", "")
+TEAM_ID = os.getenv("TEAM_ID", "")
+AGENT_A_ID = os.getenv("AGENT_A_ID", "agent-a")
+AGENT_B_ID = os.getenv("AGENT_B_ID", "agent-b")
+
+
+def auth_headers():
+    headers = {}
+    if STACK_TOKEN:
+        headers["Authorization"] = f"Bearer {STACK_TOKEN}"
+    if TEAM_ID:
+        headers["X-Team-Id"] = TEAM_ID
+    return headers
+
+
+class AgentUser(HttpUser):
+    wait_time = between(0.5, 1.5)
+
+    @task(3)
+    def single_agent_invoke(self):
+        agent_id = os.getenv("SINGLE_AGENT_ID", AGENT_A_ID)
+        payload = {"capability": "echo", "input": {"msg": "hello"}}
+        with self.client.post(
+            f"/v1/agents/{agent_id}/invoke",
+            json=payload,
+            headers=auth_headers(),
+            name="SingleAgentInvoke",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code != 200:
+                resp.failure(f"Status {resp.status_code}: {resp.text}")
+            else:
+                resp.success()
+
+    @task(2)
+    def cross_agent_invoke(self):
+        # Invoke A with a payload that causes it to trigger B (if your app supports it).
+        # For baseline, we just call A; customize to hit a true cross-agent path.
+        payload = {"capability": "cross-call", "input": {"target_agent": AGENT_B_ID}}
+        with self.client.post(
+            f"/v1/agents/{AGENT_A_ID}/invoke",
+            json=payload,
+            headers=auth_headers(),
+            name="CrossAgentInvoke",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code != 200:
+                resp.failure(f"Status {resp.status_code}: {resp.text}")
+            else:
+                resp.success()
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    parser.add_argument("--run-time", type=str, default=os.getenv("RUN_TIME", "1m"))
+    parser.add_argument("--users", type=int, default=int(os.getenv("USERS", "5")))
+    parser.add_argument("--spawn-rate", type=float, default=float(os.getenv("SPAWN_RATE", "2")))
+


### PR DESCRIPTION
This PR introduces a shared httpx.AsyncClient with connection pooling and sane timeouts, then reuses it in the OPA policy client. The client is closed during app shutdown via lifespan.

- app/services/http_client.py (get_http_client, close_http_client)
- app/security/opa.py uses shared client
- app/startup.py closes the client on shutdown

Follow-ups:
- Use the shared client for cross-agent outbound calls
- Add retry helpers and circuit-breaker in subsequent M.1 tasks


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author